### PR TITLE
feat: moved server details to ENV + cleanup go.mod

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -1,0 +1,31 @@
+package env
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+func GetStringEnv(key, fallback string) string {
+
+	val, exists := os.LookupEnv(key)
+	if !exists {
+		return fallback
+	}
+	return val
+}
+
+func GetIntEnv(key string, fallback int) int {
+
+	val, exists := os.LookupEnv(key)
+	if !exists {
+		return fallback
+	}
+
+	valInt, err := strconv.Atoi(val)
+	if err != nil {
+		log.Fatalf("Error parsing ENV key %s : %s", key, err.Error())
+
+	}
+	return valInt
+}

--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,24 @@ module github.com/Denyme24/go-dns-server
 go 1.22.0
 
 require (
- github.com/andybalholm/brotli v1.1.0 // indirect
- github.com/gofiber/fiber/v2 v2.52.6 // indirect
- github.com/google/uuid v1.6.0 // indirect
- github.com/klauspost/compress v1.17.9 // indirect
- github.com/mattn/go-colorable v0.1.13 // indirect
- github.com/mattn/go-isatty v0.0.20 // indirect
- github.com/mattn/go-runewidth v0.0.16 // indirect
- github.com/miekg/dns v1.1.64 // indirect
- github.com/rivo/uniseg v0.2.0 // indirect
- github.com/valyala/bytebufferpool v1.0.0 // indirect
- github.com/valyala/fasthttp v1.51.0 // indirect
- github.com/valyala/tcplisten v1.0.0 // indirect
- golang.org/x/mod v0.23.0 // indirect
- golang.org/x/net v0.35.0 // indirect
- golang.org/x/sync v0.11.0 // indirect
- golang.org/x/sys v0.30.0 // indirect
- golang.org/x/tools v0.30.0 // indirect
+	github.com/gofiber/fiber/v2 v2.52.6
+	github.com/miekg/dns v1.1.64
+)
+
+require (
+	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.51.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/tools v0.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/gofiber/fiber/v2 v2.52.6 h1:Rfp+ILPiYSvvVuIPvxrBns+HJp8qGLDnLJawAu27XVI=
 github.com/gofiber/fiber/v2 v2.52.6/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
@@ -31,8 +33,6 @@ golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
 golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"github.com/Denyme24/go-dns-server/env"
 	"github.com/gofiber/fiber/v2"
 	"github.com/miekg/dns"
-	"log"
 )
 
 // Our DNS records database (in-memory for this example)
@@ -25,20 +26,20 @@ func main() {
 func startDNSServer() {
 	// Set up DNS server
 	server := &dns.Server{
-		Addr: "0.0.0.0:9090", // Bind to all interfaces
-		Net:  "udp",
+		Addr: env.GetStringEnv("ADDRESS", "0.0.0.0:9090"), // Bind to all interfaces
+		Net:  env.GetStringEnv("PROTOCOLE", "udp"),
 	}
 
 	// Handle DNS requests
 	dns.HandleFunc(".", handleDNSRequest)
 
 	// Start server
-	log.Printf("Starting DNS server on port 9090...")
+	log.Printf("Starting DNS server on %s...", server.Addr)
 	err := server.ListenAndServe()
 	if err != nil {
 		log.Fatalf("Failed to start DNS server: %v", err)
 	} else {
-		log.Printf("DNS server is running on port 9090")
+		log.Printf("DNS server is running")
 	}
 }
 


### PR DESCRIPTION
Hi, 
as discussed on .dev, here is a first and basic feature, allowing users to change the server/port after compilation.
works with either entering "export ADDRESS=export ADDRESS=0.0.0.0:9091" before running it or installing direnv and creating a .env specific to your machine.
 